### PR TITLE
Add changelog support to update entity for GitHub-hosted repos

### DIFF
--- a/custom_components/gpm/_manager.py
+++ b/custom_components/gpm/_manager.py
@@ -34,6 +34,8 @@ from homeassistant.util import slugify
 from .const import (
     DOMAIN,
     DOWNLOAD_CHUNK_SIZE,
+    GITHUB_API_URL,
+    GITHUB_HOSTNAME,
     PATH_CLONE_BASEDIR,
     PATH_INTEGRATION_INSTALL_BASEDIR,
     PATH_RESOURCE_INSTALL_BASEDIR,
@@ -227,6 +229,40 @@ class RepositoryManager:
                 latest_tag = await self._get_latest_tag(only_stable=False)
             self._latest_version_cache = latest_tag or await self._get_latest_commit()
         return self._latest_version_cache
+
+    @functools.cached_property
+    def github_repo(self) -> str | None:
+        """Return the `owner/repo` slug if hosted on GitHub, else None."""
+        parsed_url = urlparse(self.repo_url)
+        if parsed_url.hostname != GITHUB_HOSTNAME:
+            return None
+        path_segments = parsed_url.path.strip("/").split("/")
+        if len(path_segments) < 2:
+            return None
+        return f"{path_segments[0]}/{path_segments[1].removesuffix('.git')}"
+
+    async def get_release_notes(self, version: str) -> str | None:
+        """Return the changelog for `version` from the repo's GitHub release.
+
+        Only supported for repos hosted on GitHub that use standard GitHub
+        releases (i.e. a release exists for the given tag). Returns None
+        otherwise.
+        """
+        if not self.github_repo:
+            return None
+        session = async_get_clientsession(self.hass)
+        url = f"{GITHUB_API_URL}/repos/{self.github_repo}/releases/tags/{version}"
+        try:
+            async with session.get(url) as response:
+                if response.status != 200:
+                    return None
+                data = await response.json()
+        except ClientError:
+            _LOGGER.warning(
+                "Failed to fetch release notes for %s@%s", self.github_repo, version
+            )
+            return None
+        return data.get("body") or None
 
     @ensure_cloned
     async def fetch(self) -> None:

--- a/custom_components/gpm/const.py
+++ b/custom_components/gpm/const.py
@@ -14,3 +14,6 @@ URL_BASE = "/gpm"
 
 GIT_SHORT_HASH_LEN = 7
 DOWNLOAD_CHUNK_SIZE = 5 * 2**20  # 2MB
+
+GITHUB_HOSTNAME = "github.com"
+GITHUB_API_URL = "https://api.github.com"

--- a/custom_components/gpm/update.py
+++ b/custom_components/gpm/update.py
@@ -46,6 +46,11 @@ class GPMUpdateEntity(UpdateEntity):
         super().__init__()
         self.manager = manager
         self._component_name: str | None = None
+        if (
+            manager.github_repo
+            and manager.update_strategy != UpdateStrategy.LATEST_COMMIT
+        ):
+            self._attr_supported_features |= UpdateEntityFeature.RELEASE_NOTES
 
     async def async_update(self) -> None:
         """Update state."""
@@ -90,3 +95,7 @@ class GPMUpdateEntity(UpdateEntity):
             raise HomeAssistantError(e) from e
         except CheckoutError as e:
             raise HomeAssistantError(f"Version `{version}` not found") from e
+
+    async def async_release_notes(self) -> str | None:
+        """Return the changelog for the latest available version."""
+        return await self.manager.get_release_notes(self.latest_version)

--- a/tests/test_manager.py
+++ b/tests/test_manager.py
@@ -6,6 +6,7 @@ from pathlib import Path
 from unittest.mock import Mock, patch
 
 import pytest
+from aiohttp import ClientError
 from custom_components.gpm import ResourceRepositoryManager
 from custom_components.gpm._manager import (
     LOVELACE_DOMAIN,
@@ -599,3 +600,65 @@ async def test_extract_zip_path_traversal(
         zip_resource_manager._extract_zip(zip_path, install_dir, "dist/card.js")
     assert (install_dir / "card.js").exists()
     assert "unsafe" in caplog.text
+
+
+@pytest.mark.parametrize(
+    ("repo_url", "expected"),
+    [
+        ("https://github.com/user/awesome-component", "user/awesome-component"),
+        ("https://github.com/user/awesome-component.git", "user/awesome-component"),
+        ("https://github.com/user/awesome-component/", "user/awesome-component"),
+        ("https://gitlab.com/user/awesome-component", None),
+        ("https://github.com/user", None),
+    ],
+)
+async def test_github_repo(
+    manager: RepositoryManager, repo_url: str, expected: str | None
+) -> None:
+    """Test github_repo parses the `owner/repo` slug from GitHub URLs only."""
+    manager.repo_url = repo_url
+    assert manager.github_repo == expected
+
+
+async def test_get_release_notes(
+    manager: RepositoryManager, aioclient_mock: AiohttpClientMocker
+) -> None:
+    """Test get_release_notes fetches the changelog body from the GitHub release."""
+    aioclient_mock.get(
+        f"https://api.github.com/repos/{manager.github_repo}/releases/tags/v1.0.0",
+        json={"body": "## Changelog\n- fixed a bug"},
+    )
+    assert await manager.get_release_notes("v1.0.0") == "## Changelog\n- fixed a bug"
+
+
+async def test_get_release_notes_no_matching_release(
+    manager: RepositoryManager, aioclient_mock: AiohttpClientMocker
+) -> None:
+    """Test get_release_notes returns None when no GitHub release exists for the tag."""
+    aioclient_mock.get(
+        f"https://api.github.com/repos/{manager.github_repo}/releases/tags/v9.9.9",
+        status=404,
+        json={"message": "Not Found"},
+    )
+    assert await manager.get_release_notes("v9.9.9") is None
+
+
+async def test_get_release_notes_non_github(manager: RepositoryManager) -> None:
+    """Test get_release_notes returns None for repos not hosted on GitHub."""
+    manager.repo_url = "https://gitlab.com/user/awesome-component"
+    assert await manager.get_release_notes("v1.0.0") is None
+
+
+async def test_get_release_notes_client_error(
+    manager: RepositoryManager,
+    aioclient_mock: AiohttpClientMocker,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test get_release_notes returns None when the GitHub API request fails."""
+    aioclient_mock.get(
+        f"https://api.github.com/repos/{manager.github_repo}/releases/tags/v1.0.0",
+        exc=ClientError,
+    )
+    with caplog.at_level(logging.WARNING):
+        assert await manager.get_release_notes("v1.0.0") is None
+    assert "Failed to fetch release notes" in caplog.text

--- a/tests/test_update.py
+++ b/tests/test_update.py
@@ -1,5 +1,7 @@
 """Tests for the GPM update entity."""
 
+from unittest.mock import AsyncMock, patch
+
 import pytest
 from custom_components.gpm._manager import (
     IntegrationRepositoryManager,
@@ -10,6 +12,7 @@ from custom_components.gpm.const import GIT_SHORT_HASH_LEN
 from custom_components.gpm.update import GPMUpdateEntity, UpdateStrategy
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
+from homeassistant.components.update import UpdateEntityFeature
 from homeassistant.const import STATE_UNAVAILABLE
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
@@ -109,3 +112,43 @@ async def test_install_non_existing_version(manager: RepositoryManager) -> None:
     with pytest.raises(HomeAssistantError):
         await entity.async_install(version="non-existing", backup=False)
     assert manager.checkout.await_count == 1
+
+
+async def test_release_notes_feature_enabled_for_github_tag_repo(
+    manager: RepositoryManager,
+) -> None:
+    """Test RELEASE_NOTES is advertised for GitHub repos using tag-based strategies."""
+    entity = GPMUpdateEntity(manager)
+    assert UpdateEntityFeature.RELEASE_NOTES in entity.supported_features
+
+
+async def test_release_notes_feature_disabled_for_latest_commit(
+    manager: RepositoryManager,
+) -> None:
+    """Test RELEASE_NOTES is not advertised when using the LATEST_COMMIT strategy."""
+    manager.update_strategy = UpdateStrategy.LATEST_COMMIT
+    entity = GPMUpdateEntity(manager)
+    assert UpdateEntityFeature.RELEASE_NOTES not in entity.supported_features
+
+
+async def test_release_notes_feature_disabled_for_non_github(
+    manager: RepositoryManager,
+) -> None:
+    """Test RELEASE_NOTES is not advertised for repos not hosted on GitHub."""
+    manager.repo_url = "https://gitlab.com/user/awesome-component"
+    entity = GPMUpdateEntity(manager)
+    assert UpdateEntityFeature.RELEASE_NOTES not in entity.supported_features
+
+
+async def test_async_release_notes(manager: RepositoryManager) -> None:
+    """Test async_release_notes delegates to the manager for the latest version."""
+    await manager.clone()
+    await manager.checkout("v0.9.9")
+    await manager.install()
+    entity = GPMUpdateEntity(manager)
+    await entity.async_update()
+    with patch.object(
+        manager, "get_release_notes", AsyncMock(return_value="## Changelog")
+    ) as get_release_notes:
+        assert await entity.async_release_notes() == "## Changelog"
+    get_release_notes.assert_awaited_once_with(entity.latest_version)


### PR DESCRIPTION
## Summary
- Adds `RepositoryManager.github_repo` to detect repos hosted on `github.com` and `RepositoryManager.get_release_notes()` to fetch the changelog body from the GitHub Releases API for a given tag
- `GPMUpdateEntity` now advertises `UpdateEntityFeature.RELEASE_NOTES` (surfacing the changelog in HA's "What's new" dialog) only for GitHub repos using tag-based update strategies (`LATEST_TAG` / `LATEST_UNSTABLE_TAG`), since `LATEST_COMMIT` and non-GitHub repos have no standard release to look up
- Non-GitHub repos or repos without a matching GitHub release simply get no changelog, with no errors surfaced to the user

## Test plan
- [x] `uv run pytest` — 124 passed
- [x] `uv run ruff check .` / `uv run ruff format --check .` — clean
- [ ] Manual check in a running HA instance that the "What's new" dialog shows release notes for a GitHub-tagged repo and is absent for non-GitHub / commit-tracked repos

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0154T9ANyJ8ns5wUycVyyj6K